### PR TITLE
Use '-' as trim char

### DIFF
--- a/bin/resolvme
+++ b/bin/resolvme
@@ -4,4 +4,4 @@
 require "resolvme"
 require "erb"
 
-puts(ERB.new(STDIN.read).result(Resolvme::Context.get_binding))
+puts(ERB.new(STDIN.read, nil, '-').result(Resolvme::Context.get_binding))


### PR DESCRIPTION
Useful when you initialize variables to trim the end of line.

E.g:

    <% foo = 'bar' -%>
    ---
    Foo: <%= foo %>

Will render like this:
    
    ---
    Foo: bar

Instead of:
```

---
Foo: bar
```