### PR TITLE
Add cache to stack output resolver

### DIFF
--- a/lib/resolvme/aws/cf_stack_output.rb
+++ b/lib/resolvme/aws/cf_stack_output.rb
@@ -8,19 +8,20 @@ module Resolvme
     class CloudformationStackOutput
       include AwsClientOptions
 
-      def initialize
+      def initialize(region = nil)
         @cache = {}
+        @region = region
       end
 
-      class OutputNotFoundError < ResolvmeError;end
+      class OutputNotFoundError < ResolvmeError; end
       # Returns a single stack output.
       #
       # @param stack_name [String] The stack name
       # @param output_key [String] The output name
       # @param region [String] AWS region
       # @return [String] The output value
-      def get_stack_output(stack_name, output_key, region = nil)
-        output = get_stack_outputs(stack_name, region).find { |o| o.output_key == output_key }
+      def get_stack_output(stack_name, output_key)
+        output = get_stack_outputs(stack_name).find { |o| o.output_key == output_key }
         raise OutputNotFoundError, "Stack output #{stack_name}/#{output_key} not found" unless output
         output.output_value
       end
@@ -31,8 +32,8 @@ module Resolvme
       # @param output_key [String] The output name
       # @param region [String] AWS region
       # @return [Array<Aws::CloudFormation::Types::Output>] Stack outputs
-      def get_stack_outputs(stack_name, stack_region = nil)
-        @cache[stack_name] ||= aws_client(:CloudFormation, stack_region).describe_stacks(stack_name: stack_name).stacks.first.outputs
+      def get_stack_outputs(stack_name)
+        @cache[stack_name] ||= aws_client(:CloudFormation, @region).describe_stacks(stack_name: stack_name).stacks.first.outputs
       end
     end
   end

--- a/lib/resolvme/aws/cf_stack_output.rb
+++ b/lib/resolvme/aws/cf_stack_output.rb
@@ -8,6 +8,10 @@ module Resolvme
     class CloudformationStackOutput
       include AwsClientOptions
 
+      def initialize
+        @cache = {}
+      end
+
       class OutputNotFoundError < ResolvmeError;end
       # Returns a single stack output.
       #
@@ -28,10 +32,8 @@ module Resolvme
       # @param region [String] AWS region
       # @return [Array<Aws::CloudFormation::Types::Output>] Stack outputs
       def get_stack_outputs(stack_name, stack_region = nil)
-        stack = aws_client(:CloudFormation, stack_region).describe_stacks(stack_name: stack_name).stacks.first
-        stack.outputs
+        @cache[stack_name] ||= aws_client(:CloudFormation, stack_region).describe_stacks(stack_name: stack_name).stacks.first.outputs
       end
-
     end
   end
 end

--- a/lib/resolvme/aws/cf_stack_output.rb
+++ b/lib/resolvme/aws/cf_stack_output.rb
@@ -8,17 +8,20 @@ module Resolvme
     class CloudformationStackOutput
       include AwsClientOptions
 
+      class OutputNotFoundError < ResolvmeError; end
+
+      # Initialize the object instance
+      # @param region [String] AWS region
+      # @return [Resolvme::Aws::CloudformationStackOutput]
       def initialize(region = nil)
         @cache = {}
         @region = region
       end
 
-      class OutputNotFoundError < ResolvmeError; end
       # Returns a single stack output.
       #
       # @param stack_name [String] The stack name
       # @param output_key [String] The output name
-      # @param region [String] AWS region
       # @return [String] The output value
       def get_stack_output(stack_name, output_key)
         output = get_stack_outputs(stack_name).find { |o| o.output_key == output_key }
@@ -27,10 +30,10 @@ module Resolvme
       end
 
       # Returns a list of outputs for a stack.
+      # Maintains a local cache to avoid redundant API requests.
       #
       # @param stack_name [String] The stack name
       # @param output_key [String] The output name
-      # @param region [String] AWS region
       # @return [Array<Aws::CloudFormation::Types::Output>] Stack outputs
       def get_stack_outputs(stack_name)
         @cache[stack_name] ||= aws_client(:CloudFormation, @region).describe_stacks(stack_name: stack_name).stacks.first.outputs


### PR DESCRIPTION
Add cache to stack output resolver, so that it doesn't have to call CloudFormation API twice for the same stack.