### PR TITLE
DP-66: Add Jenkinsfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.6.5-alpine
 
-RUN apk add --no-cache git && \
-    gem install bundler
+RUN apk add --no-cache git
 
 RUN adduser -D app && \
     mkdir /app && \
@@ -11,5 +10,5 @@ COPY --chown=app ./ /app
 USER app
 WORKDIR /app
 
-RUN bundle install --without development
+RUN gem install bundler --no-doc && bundle install --without development
 CMD ["bundle", "exec", "resolvme"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ COPY --chown=app ./ /app
 USER app
 WORKDIR /app
 
-RUN gem install bundler --no-doc && bundle install --without development
+RUN gem install bundler --no-doc && bundle install --without development test
 CMD ["bundle", "exec", "resolvme"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN adduser -D app && \
     mkdir /app && \
     chown app: /app
 
+COPY --chown=app ./ /app
 USER app
 WORKDIR /app
-COPY ./ /app
 
 RUN bundle install --without development --path vendor/
 CMD ["bundle", "exec", "resolvme"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ COPY --chown=app ./ /app
 USER app
 WORKDIR /app
 
-RUN bundle install --without development --path vendor/
+RUN bundle install --without development
 CMD ["bundle", "exec", "resolvme"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -5,4 +5,4 @@ RUN apk update && \
     apk add libc-dev gcc make
 
 USER app
-RUN bundle install --with development
+RUN bundle install --with development test

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,8 @@
+FROM resolvme:latest
+
+USER root
+RUN apk update && \
+    apk add libc-dev gcc make
+
+USER app
+RUN bundle install --with development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     byebug (11.1.1)
     coderay (1.1.2)
     diff-lcs (1.3)
+    docile (1.3.2)
     jaro_winkler (1.5.4)
     jmespath (1.4.0)
     method_source (0.9.2)
@@ -74,6 +75,10 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     unicode-display_width (1.6.1)
     vault (0.12.0)
       aws-sigv4
@@ -91,6 +96,8 @@ DEPENDENCIES
   rdoc (~> 6.2)
   resolvme!
   rspec (~> 3.8)
+  rubocop
+  simplecov
   yard (>= 0.9, < 0.10)
 
 BUNDLED WITH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,12 @@ node('docker && awsaccess') {
   }
 
   dockerTestImage.inside() {
-    stage('Run linter') {
-      sh 'bundle exec rubocop --cache false bin lib --except Style/AccessModifierDeclarations'
-      // ignore long blocks in spec files
-      sh 'bundle exec rubocop --cache false --except Metrics/BlockLength spec'
-    }
+    // TODO: fix linting issues and enable this section
+    //stage('Run linter') {
+    //  sh 'bundle exec rubocop --cache false bin lib --except Style/AccessModifierDeclarations'
+    //  // ignore long blocks in spec files
+    //  sh 'bundle exec rubocop --cache false --except Metrics/BlockLength spec'
+    //}
 
     stage('Run unit tests') {
       sh 'bundle exec rake spec'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node('docker && awsaccess') {
 
   dockerTestImage.inside() {
     stage('Run linter') {
-      sh 'bundle exec rubocop --cache false bin lib spec || true'
+      sh 'bundle exec rubocop --fail-level=F'
     }
 
     stage('Run unit tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+#!/usr/bin/env groovy
+
+node('docker && awsaccess') {
+  cleanWorkspace()
+
+  stage('Build docker image') {
+    checkout scm
+    def imageId = 'docker.io/resolvme:latest'
+    dockerImage = docker.build('resolvme:latest')
+    dockerTestImage = docker.build('resolvme:jenkins', "-f Dockerfile-dev .")
+  }
+
+  dockerTestImage.inside() {
+    stage('Run linter') {
+      sh 'bundle exec rubocop --cache false bin lib --except Style/AccessModifierDeclarations'
+      // ignore long blocks in spec files
+      sh 'bundle exec rubocop --cache false --except Metrics/BlockLength spec'
+    }
+
+    stage('Run unit tests') {
+      sh 'bundle exec rake spec'
+    }
+
+    stage('Publish coverage report') {
+      publishHTML([
+        allowMissing: false,
+        alwaysLinkToLastBuild: true,
+        keepAll: false,
+        reportDir: 'coverage',
+        reportFiles: 'index.html',
+        reportName: 'Coverage report'
+      ])
+    }
+
+    stage('Generate documentation') {
+      sh 'bundle exec yard doc --exclude vendor .'
+      publishHTML([
+        allowMissing: false,
+        alwaysLinkToLastBuild: true,
+        keepAll: false,
+        reportDir: 'doc',
+        reportFiles: 'index.html',
+        reportName: 'Loki documentation'
+      ])
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ node('docker && awsaccess') {
         keepAll: false,
         reportDir: 'doc',
         reportFiles: 'index.html',
-        reportName: 'Loki documentation'
+        reportName: 'Resolvme documentation'
       ])
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,12 +11,9 @@ node('docker && awsaccess') {
   }
 
   dockerTestImage.inside() {
-    // TODO: fix linting issues and enable this section
-    //stage('Run linter') {
-    //  sh 'bundle exec rubocop --cache false bin lib --except Style/AccessModifierDeclarations'
-    //  // ignore long blocks in spec files
-    //  sh 'bundle exec rubocop --cache false --except Metrics/BlockLength spec'
-    //}
+    stage('Run linter') {
+      sh 'bundle exec rubocop --cache false bin lib spec || true'
+    }
 
     stage('Run unit tests') {
       sh 'bundle exec rake spec'

--- a/resolvme.gemspec
+++ b/resolvme.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard", ">= 0.9", "< 0.10"
   spec.add_development_dependency "pry", ">= 0.12", "< 0.13"
   spec.add_development_dependency "pry-byebug", "~> 3.8"
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'rubocop'
   spec.add_dependency "vault", ">= 0.12", "< 0.13"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1.24"
   spec.add_dependency "aws-sdk-acm", "~> 1.24"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 require "rspec"
 require "resolvme"
+require "simplecov"
+
+SimpleCov.start do
+  add_filter 'spec'
+  add_filter 'vendor'
+end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
-require "rspec"
-require "resolvme"
 require "simplecov"
 
 SimpleCov.start do
   add_filter 'spec'
   add_filter 'vendor'
 end
+
+require "rspec"
+require "resolvme"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Add Jenkins build.

Currently rubocop checks are disabled as they will make the test fail, we need to fix the style and then enable them back.

Added `simplecov` gem for the coverage report.